### PR TITLE
Eclipse plugin can reuse the Android SDK location.

### DIFF
--- a/src/org/xwalk/ide/eclipse/xdt/XdtConstants.java
+++ b/src/org/xwalk/ide/eclipse/xdt/XdtConstants.java
@@ -26,6 +26,10 @@ public class XdtConstants {
 	/** Nature of default Android projects */
 	public final static String NATURE_ID = "org.xwalk.ide.eclipse.xdt.XwalkNature";
 
+	public final static String ADT_PLUGIN_ID = "com.android.ide.eclipse.adt";
+
+	public final static String PREFS_SDK_DIR = ADT_PLUGIN_ID + ".sdk";
+
 	public final static String MANIFEST_PATH = "manifest.json";
 
 	public static final String[] TARGET_FORMATS = { "APK", "XPK" };

--- a/src/org/xwalk/ide/eclipse/xdt/helpers/ExportHelper.java
+++ b/src/org/xwalk/ide/eclipse/xdt/helpers/ExportHelper.java
@@ -29,8 +29,11 @@ import java.util.Map;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.IPreferencesService;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.xwalk.ide.eclipse.xdt.Activator;
+import org.xwalk.ide.eclipse.xdt.XdtConstants;
 import org.xwalk.ide.eclipse.xdt.XdtPluginLog;
 import org.xwalk.ide.eclipse.xdt.preference.Settings;
 import org.xwalk.ide.eclipse.xdt.wizards.export.ApkParameters;
@@ -53,11 +56,21 @@ public final class ExportHelper {
 		return runResult;
 	}
 
+	public static String getSdkPath() {
+		IPreferencesService service = Platform.getPreferencesService();
+		String qualifier = XdtConstants.ADT_PLUGIN_ID;
+		String key = XdtConstants.PREFS_SDK_DIR;
+		String defaultValue = "";
+		String androidSdkPath = service.getString(qualifier, key, defaultValue,
+				null);
+		return androidSdkPath;
+	}
+
 	public static int generateApk(IProject project, ApkParameters parameters)
 			throws IOException {
 		StringBuilder cmd = new StringBuilder();
 		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
-		String androidSdkPath = store.getString(Settings.ANDROID_SDK_PATH);
+		String androidSdkPath = getSdkPath();
 		String xwalkPath = store.getString(Settings.XWALK_PATH);
 		File xwalkDir = new File(xwalkPath);
 		String projectPath = project.getLocation().toFile().getAbsolutePath();

--- a/src/org/xwalk/ide/eclipse/xdt/preference/Settings.java
+++ b/src/org/xwalk/ide/eclipse/xdt/preference/Settings.java
@@ -18,7 +18,6 @@ package org.xwalk.ide.eclipse.xdt.preference;
 
 public class Settings {
 	public static final String XWALK_PATH = "XWALK_PATH";
-	public static final String ANDROID_SDK_PATH = "ANDROID_SDK_PATH";
 	private Settings() {
 	}
 }

--- a/src/org/xwalk/ide/eclipse/xdt/preference/settingPage.java
+++ b/src/org/xwalk/ide/eclipse/xdt/preference/settingPage.java
@@ -41,15 +41,13 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.osgi.framework.Bundle;
 import org.xwalk.ide.eclipse.xdt.Activator;
+import org.xwalk.ide.eclipse.xdt.helpers.ExportHelper;
 
 public class settingPage extends PreferencePage implements
 		IWorkbenchPreferencePage, SelectionListener {
 	private Text mXwalkPathText;
 	private static String sLastXwalkLocation = "";
-	private static String sLastAndroidLocation = "";
 	private Button mXwalkPathBrowseButton;
-	private Text mAndroidPathTxt;
-	private Button mAndroidPathBrowseButton;
 
 	public settingPage() {
 		setTitle("Crosswalk App");
@@ -100,120 +98,91 @@ public class settingPage extends PreferencePage implements
 		androidSettingGroup.setLayout(new GridLayout(1, false));
 
 		Label androidPathLabel = new Label(androidSettingGroup, SWT.NONE);
-		androidPathLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-		androidPathLabel.setText("SDK Path:");
-		mAndroidPathTxt = new Text(androidSettingGroup, SWT.BORDER);
-		mAndroidPathTxt.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-		mAndroidPathBrowseButton = new Button(androidSettingGroup, SWT.NONE);
-		mAndroidPathBrowseButton.setText("Browse...");
-		mAndroidPathBrowseButton.addSelectionListener(this);
-		mAndroidPathBrowseButton.setEnabled(true);
+		androidPathLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true,	false, 1, 1));
+		androidPathLabel.setText("The SDK path can be set in Window->Preferences->Android.\n"
+					+ "Your SDK Path is " + ExportHelper.getSdkPath());
 		initializeValues();
 		return composite;
 	}
 
 	// ---- Implements SelectionListener ----
 
-		@Override
-		public void widgetSelected(SelectionEvent e) {
-			// TODO:
-			Object source = e.getSource();
-			if (source == mXwalkPathBrowseButton) {
-				String dir = promptUserForLocation(getShell(), "XwalkPath", "Select folder for Crosswalk path");
-				if (dir != null) {
-					mXwalkPathText.setText(dir);
-				}
-			}
-			else if (source == mAndroidPathBrowseButton) {
-				String dir = promptUserForLocation(getShell(), "AndroidPath", "Select folder for Android SDK path");
-				if (dir != null) {
-					mAndroidPathTxt.setText(dir);
-				}
+	@Override
+	public void widgetSelected(SelectionEvent e) {
+		// TODO:
+		Object source = e.getSource();
+		if (source == mXwalkPathBrowseButton) {
+			String dir = promptUserForLocation(getShell(), "XwalkPath",
+					"Select folder for Crosswalk path");
+			if (dir != null) {
+				mXwalkPathText.setText(dir);
 			}
 		}
+	}
 
+	private String promptUserForLocation(Shell shell, String forText,
+			String message) {
+		DirectoryDialog dd = new DirectoryDialog(getShell());
+		dd.setMessage(message);
+		String curLocation;
+		String dir;
 
-		private String promptUserForLocation(Shell shell, String forText, String message) {
-			DirectoryDialog dd = new DirectoryDialog(getShell());
-			dd.setMessage(message);
-			String curLocation;
-			String dir;
-
-			if (forText == "XwalkPath") {
-				curLocation = mXwalkPathText.getText().trim();
-				if (!curLocation.isEmpty()) {
-					dd.setFilterPath(curLocation);
-				} else if (sLastXwalkLocation != null) {
-					dd.setFilterPath(sLastXwalkLocation);
-				}
-			} else {
-				curLocation = mAndroidPathTxt.getText().trim();
-				if (!curLocation.isEmpty()) {
-					dd.setFilterPath(curLocation);
-				} else if (sLastAndroidLocation != null) {
-					dd.setFilterPath(sLastAndroidLocation);
-				}
-			}
-			dir = dd.open();
-			if ((dir != null) && (forText == "XwalkPath")) {
-				sLastXwalkLocation = dir;
-			}
-			else {
-				sLastAndroidLocation = dir;
-			}
-			return dir;
-		}
-
-		@Override
-		public void widgetDefaultSelected(SelectionEvent e) {
-
-		}
-
-		private void initializeValues () {
-			IPreferenceStore store = Activator.getDefault().getPreferenceStore();
-			if ((store.getString(Settings.XWALK_PATH) == "")||(store.getString(Settings.XWALK_PATH) == null)) {
-				store.setDefault(Settings.XWALK_PATH, System.getProperty("user.home"));
-				sLastXwalkLocation = System.getProperty("user.home");
-			} else {
-				sLastXwalkLocation = store.getString(Settings.XWALK_PATH);
-			}
-
-			if ((store.getString(Settings.ANDROID_SDK_PATH) == "")||(store.getString(Settings.ANDROID_SDK_PATH) == null)) {
-				store.setDefault(Settings.ANDROID_SDK_PATH, System.getProperty("user.home"));
-				sLastAndroidLocation = System.getProperty("user.home");
-			} else {
-				sLastAndroidLocation = store.getString(Settings.ANDROID_SDK_PATH);
-			}
-
-			if (sLastXwalkLocation != "") {
-				mXwalkPathText.setText(sLastXwalkLocation);
-			}
-
-			if (sLastAndroidLocation != "") {
-				mAndroidPathTxt.setText(sLastAndroidLocation);
+		if (forText == "XwalkPath") {
+			curLocation = mXwalkPathText.getText().trim();
+			if (!curLocation.isEmpty()) {
+				dd.setFilterPath(curLocation);
+			} else if (sLastXwalkLocation != null) {
+				dd.setFilterPath(sLastXwalkLocation);
 			}
 		}
+		dir = dd.open();
+		if ((dir != null) && (forText == "XwalkPath")) {
+			sLastXwalkLocation = dir;
+		}
+		return dir;
+	}
 
-		private void storeValues() {
-			IPreferenceStore store = Activator.getDefault().getPreferenceStore();
-			store.setValue(Settings.XWALK_PATH, mXwalkPathText.getText().trim());
-			store.setValue(Settings.ANDROID_SDK_PATH, mAndroidPathTxt.getText().trim());
+	@Override
+	public void widgetDefaultSelected(SelectionEvent e) {
+
+	}
+
+	private void initializeValues() {
+		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
+		if ((store.getString(Settings.XWALK_PATH) == "")
+				|| (store.getString(Settings.XWALK_PATH) == null)) {
+			store.setDefault(Settings.XWALK_PATH,
+					System.getProperty("user.home"));
+			sLastXwalkLocation = System.getProperty("user.home");
+		} else {
+			sLastXwalkLocation = store.getString(Settings.XWALK_PATH);
 		}
 
-		private void initializeDefaults() {
-			IPreferenceStore store = Activator.getDefault().getPreferenceStore();
-			System.out.println("store.getDefaultString(Settings.XWALK_PATH):"+store.getDefaultString(Settings.XWALK_PATH));
-			mXwalkPathText.setText(store.getDefaultString(Settings.XWALK_PATH));
-			mAndroidPathTxt.setText(store.getDefaultString(Settings.ANDROID_SDK_PATH));
+		if (sLastXwalkLocation != "") {
+			mXwalkPathText.setText(sLastXwalkLocation);
 		}
 
-		protected void performDefaults () {
-			initializeDefaults();
-			super.performDefaults();
-		}
+	}
 
-		public boolean performOk () {
-			storeValues();
-			return true;
-		}
+	private void storeValues() {
+		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
+		store.setValue(Settings.XWALK_PATH, mXwalkPathText.getText().trim());
+	}
+
+	private void initializeDefaults() {
+		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
+		System.out.println("store.getDefaultString(Settings.XWALK_PATH):"
+				+ store.getDefaultString(Settings.XWALK_PATH));
+		mXwalkPathText.setText(store.getDefaultString(Settings.XWALK_PATH));
+	}
+
+	protected void performDefaults() {
+		initializeDefaults();
+		super.performDefaults();
+	}
+
+	public boolean performOk() {
+		storeValues();
+		return true;
+	}
 }

--- a/src/org/xwalk/ide/eclipse/xdt/wizards/export/ExportProjectPage.java
+++ b/src/org/xwalk/ide/eclipse/xdt/wizards/export/ExportProjectPage.java
@@ -82,7 +82,6 @@ public class ExportProjectPage extends WizardPage implements ModifyListener,
 	private Label mKeyStoreAliasLabel;
 	private Label mKeyStorePassCodeLabel;
 
-
 	protected ExportProjectPage(ExportProjectWizard wizard) {
 		super("exportCrosswalkApp");
 		mWizard = wizard;
@@ -98,7 +97,9 @@ public class ExportProjectPage extends WizardPage implements ModifyListener,
 		mSettingCanFinish = true;
 		if (!checkPreferenceSettings()) {
 			mSettingCanFinish = false;
-			setMessage("Android SDK or Crosswalk path have not been set correctly. Please go Windwo->Preferences->Crosswalk App to set it up.", WARNING);
+			setMessage("Crosswalk's path has not been set correctly. Please go to Window->"
+					+ "Preferences->Crosswalk App to configure it.",
+					WARNING);
 		}
 		setPageComplete(false);
 	}
@@ -294,12 +295,7 @@ public class ExportProjectPage extends WizardPage implements ModifyListener,
 
 	private boolean checkPreferenceSettings() {
 		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
-		String androidSdkPath = store.getString(Settings.ANDROID_SDK_PATH);
 		String xwalkPath = store.getString(Settings.XWALK_PATH);
-		File androidSdk = new File(androidSdkPath);
-		if (!androidSdk.exists()) {
-			return false;
-		}
 
 		File xwalk = new File(xwalkPath);
 		if (!xwalk.exists()) {
@@ -307,8 +303,8 @@ public class ExportProjectPage extends WizardPage implements ModifyListener,
 		}
 		return true;
 	}
-	@Override
 
+	@Override
 	public void setVisible(boolean visible) {
 		super.setVisible(visible);
 		if (visible) {
@@ -418,7 +414,6 @@ public class ExportProjectPage extends WizardPage implements ModifyListener,
 
 		CanFinish();
 	}
-
 
 	private void onDestinationChange() {
 		String path = mDestinationPathText.getText().trim();
@@ -549,7 +544,7 @@ public class ExportProjectPage extends WizardPage implements ModifyListener,
 		curLocation = textWidget.getText().trim();
 		if (!curLocation.isEmpty()) {
 			dd.setFilterPath(curLocation);
-		} 
+		}
 
 		dir = dd.open();
 		return dir;

--- a/src/org/xwalk/ide/eclipse/xdt/wizards/export/ExportProjectWizard.java
+++ b/src/org/xwalk/ide/eclipse/xdt/wizards/export/ExportProjectWizard.java
@@ -88,7 +88,7 @@ public class ExportProjectWizard extends Wizard implements IExportWizard {
 
 	private boolean checkPreferenceSettings() {
 		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
-		String androidSdkPath = store.getString(Settings.ANDROID_SDK_PATH);
+		String androidSdkPath = ExportHelper.getSdkPath();
 		String xwalkPath = store.getString(Settings.XWALK_PATH);
 		File androidSdk = new File(androidSdkPath);
 		if (!androidSdk.exists()) {


### PR DESCRIPTION
Add getSdkPath() method in ExportHelper.java. Get SDK Path from ADT preference.
Instead of input sdk path manually.

BUG=XWALK-1929
